### PR TITLE
Add Django REST Framework to project

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 asgiref==3.8.1
 Django==4.2
+djangorestframework==3.15.1
 sqlparse==0.5.0
 typing_extensions==4.12.0
 tzdata==2024.1

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -31,12 +31,18 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    # Django built-in apps
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    
+    # Third-party apps
+    'rest_framework',
+    
+    
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
- Installed Django REST Framework (DRF) by adding it to the environment
- Added 'rest_framework' to the INSTALLED_APPS setting in Django
- Updated 'requirements.txt' file